### PR TITLE
Prepare Pie Chart Blog post

### DIFF
--- a/PieChartDemo/App.xaml.cs
+++ b/PieChartDemo/App.xaml.cs
@@ -6,6 +6,6 @@ public partial class App : Application
 	{
 		InitializeComponent();
 
-		MainPage = new AppShell();
+		MainPage = new MainPage();
 	}
 }

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -16,7 +16,8 @@
             <Chart:SfCircularChart.Title>
                 <Label Text="2021 U.S. Methane Emissions, By Source"
                         HorizontalTextAlignment="Center" TextColor="White"
-                       FontSize="Medium" FontAttributes="Bold" BackgroundColor="#199CB3"/>
+                       FontSize="{OnPlatform WinUI='Medium', MacCatalyst='40', iOS='Medium', Android='Medium'}"
+                       FontAttributes="Bold" BackgroundColor="#199CB3"/>
             </Chart:SfCircularChart.Title>
 
             <Chart:SfCircularChart.TooltipBehavior>
@@ -40,7 +41,8 @@
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
                         <Label Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
-                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='300', iOS='300', Android='130'}" 
+                               FontSize="{OnPlatform WinUI='14', MacCatalyst='Large', iOS='Small', Android='Small'}"
+                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='500', iOS='300', Android='130'}" 
                                    LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
                                    VerticalOptions="Fill" HorizontalTextAlignment="Center"/>
                     </DataTemplate>

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -6,72 +6,46 @@
              xmlns:local="clr-namespace:PieChartDemo">
 
     <Grid Margin="10,15,10,10">
+
         <Grid.BindingContext>
             <local:PieChartViewModel/>
         </Grid.BindingContext>
-        <Grid.Resources>
-            <local:ColorConverter x:Key="converter"/>
-        </Grid.Resources>
+
         <Chart:SfCircularChart x:Name="chart">
+
             <Chart:SfCircularChart.Title>
-                <VerticalStackLayout>
-                    <Label Text="Share of victims by hate crime bias type in 2021*"
-                        HorizontalTextAlignment="Center" TextColor="#FF455E7A"
-                       FontSize="Title" FontAttributes="Bold"/>
-                    <Label Text="*The total reported hate crime victims may not equal 100 due to rounding."
-                        HorizontalTextAlignment="Center" TextColor="#FF455E7A"
-                       FontSize="12" FontAttributes="Bold"/>
-                </VerticalStackLayout>
+                <Label Text="2021 U.S. Methane Emissions, By Source"
+                        HorizontalTextAlignment="Center" TextColor="White"
+                       FontSize="Medium" FontAttributes="Bold" BackgroundColor="#199CB3"/>
             </Chart:SfCircularChart.Title>
-            <Chart:SfCircularChart.Legend>
-                <Chart:ChartLegend Placement="Right">
-                    <Chart:ChartLegend.ItemTemplate>
-                        <DataTemplate>
-                            <StackLayout Orientation="Horizontal" >
-                                <Ellipse HeightRequest="15" WidthRequest="15" 
-                                           Fill="{Binding IconBrush}"/>
-                                <Label Margin="3,0,10,0" VerticalTextAlignment="Center"
-                                       Text="{Binding Text}"
-                                       FontSize="{OnPlatform WinUI='20', MacCatalyst='20', iOS='15', Android='15'}" TextColor="Black"/>
-                            </StackLayout>
-                        </DataTemplate>
-                    </Chart:ChartLegend.ItemTemplate>
-                </Chart:ChartLegend>
-            </Chart:SfCircularChart.Legend>
+
             <Chart:SfCircularChart.TooltipBehavior>
-                <Chart:ChartTooltipBehavior Background="#7D000000"/>
+                <Chart:ChartTooltipBehavior />
             </Chart:SfCircularChart.TooltipBehavior>
-            <Chart:PieSeries XBindingPath="CrimeBiasType" YBindingPath="PercentageOfVictims"
-                             ItemsSource="{Binding Data}" 
+
+            <Chart:PieSeries XBindingPath="EmissionSource" YBindingPath="EmissionPercentage"
+                             ItemsSource="{Binding Data}" ExplodeIndex="2" Stroke="White" StrokeWidth="2"
                              PaletteBrushes="{Binding CustomBrushes}"
-                              ShowDataLabels="True" StartAngle="20" EndAngle="380"
+                              ShowDataLabels="True" StartAngle="270" EndAngle="630"
                              EnableTooltip="True">
+
                 <Chart:PieSeries.DataLabelSettings>
-                    <Chart:CircularDataLabelSettings LabelPlacement="{OnPlatform WinUI='Outer', MacCatalyst='Outer', iOS='Auto', Android='Auto'}">
+                    <Chart:CircularDataLabelSettings UseSeriesPalette="True" LabelPlacement="Outer">
                         <Chart:CircularDataLabelSettings.LabelStyle>
                             <Chart:ChartDataLabelStyle LabelFormat="0.##'%"/>
                         </Chart:CircularDataLabelSettings.LabelStyle>
                     </Chart:CircularDataLabelSettings>
                 </Chart:PieSeries.DataLabelSettings>
+
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition/>
-                                <RowDefinition/>
-                            </Grid.RowDefinitions>
-                            <Label Text="{Binding Item.CrimeBiasType}" FontAttributes="Bold"
-                                   TextColor="White"/>
-                            <HorizontalStackLayout Grid.Row="1">
-                                <Rectangle HeightRequest="15" WidthRequest="15" Margin="2"
-                                           Stroke="white" StrokeThickness="3"
-                                           Fill="{Binding Converter={StaticResource converter}}"/>
-                                <Label Text="{Binding Item.Victims, StringFormat=' data: {0:N0}'}" 
-                                       TextColor="White" VerticalTextAlignment="Center"/>
-                            </HorizontalStackLayout>
-                        </Grid>
+                        <Label Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
+                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='140', iOS='130', Android='130'}" 
+                                   LineBreakMode="WordWrap" HorizontalOptions="Fill"
+                                   VerticalOptions="Center" HorizontalTextAlignment="Center"/>
                     </DataTemplate>
                 </Chart:PieSeries.TooltipTemplate>
+
             </Chart:PieSeries>
         </Chart:SfCircularChart>
     </Grid>

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -43,9 +43,9 @@
 
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
-                        <Grid ColumnDefinitions="{OnPlatform iOS='160', MacCatalyst='160'}" RowDefinitions="Auto"> 
+                        <Grid ColumnDefinitions="{OnPlatform iOS='160', MacCatalyst='200'}" RowDefinitions="Auto"> 
                         <Label Grid.Row="0" Grid.Column="0" Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
-                               FontSize="{OnPlatform MacCatalyst='Medium'}"
+                               FontSize="{OnPlatform MacCatalyst='Large'}"
                                TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', Android='130'}" 
                                LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
                                VerticalOptions="Fill" HorizontalTextAlignment="Center"/>

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -16,7 +16,7 @@
             <Chart:SfCircularChart.Title>
                 <Label Text="2021 U.S. Methane Emissions, By Source"
                         HorizontalTextAlignment="Center" TextColor="White"
-                       FontSize="{OnPlatform WinUI='Medium', MacCatalyst='40', iOS='Medium', Android='Medium'}"
+                       FontSize="{OnPlatform WinUI='Medium', MacCatalyst='35', iOS='Medium', Android='Medium'}"
                        FontAttributes="Bold" BackgroundColor="#199CB3"/>
             </Chart:SfCircularChart.Title>
 

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -41,7 +41,7 @@
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
                         <Label Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
-                               FontSize="{OnPlatform WinUI='14', MacCatalyst='Large', iOS='Small', Android='Small'}"
+                               FontSize="{OnPlatform MacCatalyst='Large'}"
                                    TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='500', iOS='300', Android='130'}" 
                                    LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
                                    VerticalOptions="Fill" HorizontalTextAlignment="Center"/>

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -14,10 +14,13 @@
         <Chart:SfCircularChart x:Name="chart">
 
             <Chart:SfCircularChart.Title>
-                <Label Text="2021 U.S. Methane Emissions, By Source"
+                <Border StrokeShape="{OnPlatform WinUI='RoundRectangle 8', Android='RoundRectangle 5', MacCatalyst='RoundRectangle 15', iOS='RoundRectangle 8'}"
+                        Stroke="#199CB3" BackgroundColor="#199CB3" StrokeThickness="3">
+                <Label Text="2021 U.S. Methane Emissions, By Source" 
                         HorizontalTextAlignment="Center" TextColor="White"
                        FontSize="{OnPlatform WinUI='Medium', MacCatalyst='35', iOS='Medium', Android='Medium'}"
                        FontAttributes="Bold" BackgroundColor="#199CB3"/>
+                </Border>
             </Chart:SfCircularChart.Title>
 
             <Chart:SfCircularChart.TooltipBehavior>
@@ -40,11 +43,13 @@
 
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
-                        <Label Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
-                               FontSize="{OnPlatform MacCatalyst='Large'}"
-                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='500', iOS='300', Android='130'}" 
-                                   LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
-                                   VerticalOptions="Fill" HorizontalTextAlignment="Center"/>
+                        <Grid ColumnDefinitions="{OnPlatform iOS='160', MacCatalyst='160'}" RowDefinitions="Auto"> 
+                        <Label Grid.Row="0" Grid.Column="0" Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
+                               FontSize="{OnPlatform MacCatalyst='Medium'}"
+                               TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', Android='130'}" 
+                               LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
+                               VerticalOptions="Fill" HorizontalTextAlignment="Center"/>
+                        </Grid>
                     </DataTemplate>
                 </Chart:PieSeries.TooltipTemplate>
 

--- a/PieChartDemo/MainPage.xaml
+++ b/PieChartDemo/MainPage.xaml
@@ -40,9 +40,9 @@
                 <Chart:PieSeries.TooltipTemplate>
                     <DataTemplate>
                         <Label Text="{Binding Item.EmissionSource}" FontAttributes="Bold" 
-                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='140', iOS='130', Android='130'}" 
-                                   LineBreakMode="WordWrap" HorizontalOptions="Fill"
-                                   VerticalOptions="Center" HorizontalTextAlignment="Center"/>
+                                   TextColor="White" MaximumWidthRequest="{OnPlatform WinUI='140', MacCatalyst='300', iOS='300', Android='130'}" 
+                                   LineBreakMode="WordWrap" HorizontalOptions="Fill" VerticalTextAlignment="Center"
+                                   VerticalOptions="Fill" HorizontalTextAlignment="Center"/>
                     </DataTemplate>
                 </Chart:PieSeries.TooltipTemplate>
 

--- a/PieChartDemo/MainPage.xaml.cs
+++ b/PieChartDemo/MainPage.xaml.cs
@@ -10,25 +10,5 @@ namespace PieChartDemo
             InitializeComponent();
         }
     }
-    
-    public class ColorConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            TooltipInfo tooltipInfo = (TooltipInfo)value;
-
-            if (tooltipInfo != null)
-            {
-                var viewModel = (tooltipInfo.Source as PieSeries).BindingContext as PieChartViewModel;
-                return (viewModel.CustomBrushes[tooltipInfo.Index] as SolidColorBrush).Color;
-            }
-            else { return null; }
-        }
-
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 }
 

--- a/PieChartDemo/Model/PieChartModel.cs
+++ b/PieChartDemo/Model/PieChartModel.cs
@@ -8,8 +8,7 @@ namespace PieChartDemo
 {
     public class PieChartModel
     {
-        public string CrimeBiasType { get; set; }
-        public double PercentageOfVictims { get; set; }
-        public double Victims { get; set; }
+        public string EmissionSource { get; set; }
+        public double EmissionPercentage { get; set; }
     }
 }

--- a/PieChartDemo/ViewModel/PieChartViewModel.cs
+++ b/PieChartDemo/ViewModel/PieChartViewModel.cs
@@ -12,19 +12,23 @@ namespace PieChartDemo
         {
             Data = new List<PieChartModel>()
             {
-            new PieChartModel() { CrimeBiasType = "Race/Ethnicity/Ancestry", PercentageOfVictims = 65.64461965,Victims = 4496 },
-            new PieChartModel() { CrimeBiasType = "Religion", PercentageOfVictims = 14.79048, Victims = 1013 },
-            new PieChartModel() { CrimeBiasType = "Sexual Orientation", PercentageOfVictims = 16.52796, Victims = 1132 },
-            new PieChartModel() { CrimeBiasType = "Disability", PercentageOfVictims = 1.985691, Victims = 136 },
-            new PieChartModel() { CrimeBiasType = "Gender", PercentageOfVictims = 1.051248, Victims = 72 }
+            new PieChartModel() { EmissionSource = "Natural Gas and Petroleum Systems", EmissionPercentage = 32},
+            new PieChartModel() { EmissionSource = "Enteric Fermentation", EmissionPercentage = 27},
+            new PieChartModel() { EmissionSource = "MSW Landfills", EmissionPercentage = 14 },
+            new PieChartModel() { EmissionSource = "Other Landfills", EmissionPercentage = 3 },
+            new PieChartModel() { EmissionSource = "Manure Management", EmissionPercentage = 9 },
+            new PieChartModel() { EmissionSource = "Coal Mining", EmissionPercentage = 6 },
+            new PieChartModel() { EmissionSource = "Other", EmissionPercentage = 9 }
             };
 
             CustomBrushes = new List<Brush>();
-            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#FF701421")));
-            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#FFBA261A")));
-            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#FFEB3527")));
-            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#FFF6ABAF")));
-            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#FFF5D3D4")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#0E778A")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#3499AB")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#199CB3")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#42B6CB")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#6BCBDC")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#84D7E6")));
+            CustomBrushes.Add(new SolidColorBrush(Color.FromArgb("#89DCEb")));
         }
 
         public List<PieChartModel> Data { get; set; }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pie Chart Illustrating US Methane Emissions in 2021
-The pie chart is a graphical representation which helps to organize and show data as a percentage of a whole. This sample demonstrates how to create a Pie Chart demonstrates the Methane Emission from various sources in the United States during the year 2021 using .NET MAUI (SfCircularChart).
+The pie chart is a graphical representation which helps to organize and show data as a percentage of a whole. This sample demonstrates how to create a Pie Chart illustrating the Methane Emission from various sources in the United States during the year 2021 using .NET MAUI (SfCircularChart).
 
-<img width="699" alt="PieChartImage" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/8702f757-97d4-45c1-b015-be2e807fb0f4">
+<img width="710" alt="PieChartWindows" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/0abb3459-826e-4423-8d95-e12d60ad65bd">
+
 
 For a step by step procedure, refer to the [Pie Chart Illustrating US Methane Emissions blog]()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Creating a Pie Chart to demonstrate the Share of Victims by Hate Crime Bias Types
-The pie chart is a graphical representation which helps to organize and show data as a percentage of a whole. This sample demonstrates how to create a Pie Chart that shows the Share of Victims by Hate Crime Bias Types in .NET MAUI (SfCircularChart).
+# Pie Chart Illustrating US Methane Emissions in 2021
+The pie chart is a graphical representation which helps to organize and show data as a percentage of a whole. This sample demonstrates how to create a Pie Chart demonstrates the Methane Emission from various sources in the United States during the year 2021 using .NET MAUI (SfCircularChart).
 
-<img width="649" alt="PieChartImage" src="https://user-images.githubusercontent.com/105496706/233118589-7d146eca-77ac-4b5b-86b0-8d1cebf07f56.png">
+<img width="699" alt="PieChartImage" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/8702f757-97d4-45c1-b015-be2e807fb0f4">
 
-For a step by step procedure, refer to the [Share of Victims by Hate Crime Bias Types blog]()
+For a step by step procedure, refer to the [Pie Chart Illustrating US Methane Emissions blog]()


### PR DESCRIPTION
Modified the sample use case
Sample output:
Windows
<img width="710" alt="PieChartWindows" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/6f348ede-dfca-4902-8e26-15f8a1b9d9b6">

Android
<img width="706" alt="PieChartAndroid" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/a608dab9-2196-45ec-9f21-c4b69fcd86de">

MAC
<img width="519" alt="MAC" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/f1e61f42-0ce0-4be8-9d6b-e78614013a4f">

iOS
<img width="689" alt="PieChartIOS" src="https://github.com/SyncfusionExamples/Creating-a-Pie-Chart-to-demonstrate-the-Share-of-Victims-by-Hate-Crime-Bias-Types/assets/105496706/2e26975f-09d3-47b4-ae2f-5f70a7c92338">



